### PR TITLE
PISTON-1104: Adds vm_message_forward_type form control.

### DIFF
--- a/whapps/voip/vmbox/lang/en.js
+++ b/whapps/voip/vmbox/lang/en.js
@@ -46,6 +46,8 @@ window.translate['vmbox'] = {
 	not_configurable_data_content: " If unchecked, it will disallow the user to configure voicemail via the menu",
 	transcribe_voicemail: "Transcribe Messages",
 	transcribe_voicemail_data_content: "If checked, email notifications will include a best-guess transcription of voicemail messages",
+	vm_message_forward_type: "Prepend message on forward",
+	vm_message_forward_type_data_content: "If checked, the user will be prompted to record an additional message, when forwarding a voicemail message",
 	delete: "Delete",
 	save: "Save",
 	voicemail_boxes_label: "Voicemail Boxes",

--- a/whapps/voip/vmbox/lang/nl.js
+++ b/whapps/voip/vmbox/lang/nl.js
@@ -42,6 +42,8 @@ window.translate['vmbox'] = {
 	skip_envelope_data_content: "Vink aan om standaard de voicemail-envelop over te slaan",
 	delete_after_notification: "Verwijder na notificatie",
 	delete_after_notification_data_content: "verwijder het bericht nadat de notificatie is verstuurt",
+	vm_message_forward_type: "Bericht opnemen bij doorsturen",
+	vm_message_forward_type_data_content: "Indien aangevinkt, wordt de gebruiker gevraagd om een ​​extra bericht op te nemen bij het doorsturen van een voicemailbericht",
 	delete: "Verwijder",
 	save: "Opslaan",
 	voicemail_boxes_label: "Voicemail Boxes",

--- a/whapps/voip/vmbox/lang/ru.js
+++ b/whapps/voip/vmbox/lang/ru.js
@@ -42,6 +42,8 @@ window.translate['vmbox'] = $.extend(true, {}, window.translate['vmbox'], {
 	skip_envelope_data_content: "Выберите, чтобы автоматически пропускать информацию о номере, дате и времени звонка",
 	delete_after_notification: "Удалить после уведомления",
 	delete_after_notification_data_content: "Удалять голосовое сообщение после отправки уведомления",
+	vm_message_forward_type: "Предварять сообщение на пересылку",
+	vm_message_forward_type_data_content: "Если этот флажок установлен, пользователю будет предложено записать дополнительное сообщение при пересылке сообщения голосовой почты",
 	delete: "Удалить",
 	save: "Сохранить",
 	voicemail_boxes_label: "Ящики голосовой почты",

--- a/whapps/voip/vmbox/lang/zh.js
+++ b/whapps/voip/vmbox/lang/zh.js
@@ -40,6 +40,8 @@ window.translate['vmbox'] = {
 	skip_instructions_data_content: "勾选后默认跳过语音指示",
 	delete_after_notification: "通知后删除",
 	delete_after_notification_data_content: "通知邮件发出后自动删除语音留言",
+	vm_message_forward_type: "在转发之前添加消息",
+	vm_message_forward_type_data_content: "如果选中，则在转发语音邮件时，将提示用户记录其他消息",
 	delete: "删除",
 	save: "保存",
 	voicemail_boxes_label: "语音邮箱",

--- a/whapps/voip/vmbox/tmpl/edit.html
+++ b/whapps/voip/vmbox/tmpl/edit.html
@@ -263,6 +263,25 @@
                             </ul>
                         </div>
                     </div>
+
+					<div class="clearfix">
+						<div class="input">
+							<ul class="inputs-list">
+								<li>
+									<label>
+										<span rel="popover" data-content="${_t('vm_message_forward_type_data_content')}">
+											{{if data.vm_message_forward_type === "prepend_forward"}}
+												<input type="checkbox" id="vm_message_forward_type" name="vm_message_forward_type" checked="checked" />
+											{{else}}
+												<input type="checkbox" id="vm_message_forward_type" name="vm_message_forward_type" />
+											{{/if}}
+											<span>${_t('vm_message_forward_type')}</span>
+										</span>
+									</label>
+								</li>
+							</ul>
+						</div>
+					</div>	
 				</div>
 			</div>
 		 </form>

--- a/whapps/voip/vmbox/vmbox.js
+++ b/whapps/voip/vmbox/vmbox.js
@@ -428,6 +428,10 @@ function(args) {
 			delete form_data.pin;
 		}
 
+		if (typeof form_data.vm_message_forward_type === 'boolean') {
+			form_data.vm_message_forward_type = form_data.vm_message_forward_type ? 'prepend_forward' : 'only_forward';
+		}
+
 		form_data.not_configurable = !form_data.extra.allow_configuration;
 
 		delete form_data.extra;


### PR DESCRIPTION
![Screen Shot 2020-08-06 at 1 24 04 PM](https://user-images.githubusercontent.com/68124370/89690325-128dfa80-d8bb-11ea-979f-292bf76960fd.png)

The "Prepend message on forward" checkbox has been added.