### PR TITLE
KAZUI-294: Prevent bogus end-of-line changes.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-* text eol=lf
+* text=auto


### PR DESCRIPTION
Changes the `.gitattributes` file `* text eof=lf` entry to `* text=auto` to prevent binary files from being seen as having end-of-line changes.

@danielfinke 